### PR TITLE
Scan and monitor examples using libgpiod

### DIFF
--- a/libgpiod-monitor/Makefile
+++ b/libgpiod-monitor/Makefile
@@ -1,0 +1,11 @@
+PROJ=libgpiod-monitor
+SRC=main.cpp
+LIBS=-lgpiod -lpthread
+
+CFLAGS=-Wall -Werror -O2
+CXX?=c++
+all:
+	$(CXX) $(SRC) $(LIBS) $(CFLAGS) -o $(PROJ)
+
+clean:
+	rm $(PROJ)

--- a/libgpiod-monitor/README.md
+++ b/libgpiod-monitor/README.md
@@ -1,0 +1,22 @@
+# libgpiod event loop Example
+
+This is a c++ libgpiod client using event loop for monitoring a GPIO line.
+
+## Build
+```
+make
+```
+
+## Execute
+
+```
+./libgpiod-scan -n 10 -l 44
+```
+
+## Clean
+```
+make clean
+```
+### Notes
+
+By default, program waits 10 seconds for an event to appear

--- a/libgpiod-monitor/main.cpp
+++ b/libgpiod-monitor/main.cpp
@@ -1,0 +1,211 @@
+#include <atomic>
+#include <iostream>
+#include <chrono>
+#include <future>
+#include <gpiod.h>
+#include <ctype.h>
+#include <errno.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <thread>
+#include <unistd.h>
+
+
+/* constants */
+static constexpr size_t PROG_DURATION_IN_SECONDS = 10;
+
+/* Helpful banner for program usage */
+void banner(char *progName)
+{
+    std::cout << std::string(progName) << std::endl;
+    std::cout << "     -u/h  : Usage message " << std::endl;
+    std::cout << "     -n    : Number of GPIO controller to scan, Default range [0,1)" << std::endl;
+    std::cout << "     -l    : Line number to search in GPIO controllersi, Default 0" << std::endl;
+}
+
+/* Asynchronous operator managing callbacks from libgpiod */
+int async_monitor(const std::string devName, const unsigned int inLine, std::atomic<bool>& endFlag)
+{
+
+    bool eventTransition = false;
+    const struct timespec monitorTimeout = {1, 0};
+    auto poll_callback = [](unsigned int numLines, struct gpiod_ctxless_event_poll_fd* desc,
+                            const struct timespec* timeOut, void* userData) -> int
+    {
+        if (numLines != 1) {
+            std::cerr << "Invalid number of GPIO lines received" << numLines << std::endl;
+            return GPIOD_CTXLESS_EVENT_POLL_RET_ERR;
+        }
+
+        if (not desc) {
+            std::cerr << "Invalid file descriptor structure passed" << std::endl;
+            return GPIOD_CTXLESS_EVENT_POLL_RET_ERR;
+        }
+        if (not timeOut) {
+            std::cerr << "Invalid timeout structure passed" << std::endl;
+            return GPIOD_CTXLESS_EVENT_POLL_RET_ERR;
+        }
+
+        if (timeOut->tv_sec != 1U or timeOut->tv_nsec != static_cast<uint64_t>(0)) {
+            std::cerr << "Unexpected polling callback timestamp sec="
+                      <<  static_cast<uint64_t>(timeOut->tv_sec)
+                      << " nanosec=" << static_cast<uint64_t>(timeOut->tv_nsec) << std::endl;
+            return GPIOD_CTXLESS_EVENT_POLL_RET_ERR;
+        } else {
+            /* No need to set file descriptor and corresponding event if not controlling GPIO */
+            return GPIOD_CTXLESS_EVENT_POLL_RET_TIMEOUT;
+        }
+    };
+
+    auto event_callback = [inLine, &eventTransition](int event, unsigned int lineIn, const struct timespec* timeOut,
+                            void* data) -> int
+    {
+        if (event != GPIOD_CTXLESS_EVENT_RISING_EDGE and event != GPIOD_CTXLESS_EVENT_FALLING_EDGE) {
+            std::cerr << "Unexpected GPIO event=" << event << " received" << std::endl;
+            return GPIOD_CTXLESS_EVENT_CB_RET_ERR;
+        }
+        if (not timeOut) {
+            std::cerr << "Invalid timeout structure passed" << std::endl;
+            return GPIOD_CTXLESS_EVENT_CB_RET_ERR;
+        }
+        std::cout << "EventCallback timestamp: sec" << static_cast<uint64_t>(timeOut->tv_sec) <<
+                     " nanosec=" << static_cast<uint64_t>(timeOut->tv_nsec) << std::endl;
+        if (lineIn != inLine) {
+            std::cerr << "Event received for unwanted GPIO line=" << lineIn << std::endl;
+            return GPIOD_CTXLESS_EVENT_CB_RET_STOP;
+        }
+
+        eventTransition = event == GPIOD_CTXLESS_EVENT_RISING_EDGE ? true : false;
+        return GPIOD_CTXLESS_EVENT_CB_RET_OK;
+    };
+
+    auto event_callback_wrapper = [](int event, unsigned int lineIn, const struct timespec* timeOut, void* data)-> int {
+        return (*static_cast<decltype(event_callback)*>(data))(event, lineIn, timeOut, NULL);
+    };
+
+    auto retVal = gpiod_ctxless_event_monitor(devName.c_str(),
+                                              GPIOD_CTXLESS_EVENT_RISING_EDGE,
+                                              inLine,
+                                              false,
+                                              "LSMF",
+                                              &monitorTimeout,
+                                              poll_callback,
+                                              event_callback_wrapper,
+                                              &event_callback);
+    if (retVal != 0) {
+        std::cerr << "Event monitoring for GPIO Line=" << inLine << " Failed! with error=" << errno << std::endl;
+        return retVal;
+    } else {
+        std::cout << "Callbacks successfully registered, this thread will just wait now for callbacks to take over" << std::endl;
+        while(not endFlag) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            if (eventTransition) {
+                std::cout << "GPIO event registered!" << std::endl;
+            }
+        }
+        return 0;
+    }
+}
+
+/* libgpiod client driver for demonstrating context less event loop */
+int main(int argc, char **argv)
+{
+
+    int optIn = 0;
+    int numDevices = -1;
+    unsigned int numLine = 0;
+
+    /* Boilerplate command line arguments processing */
+    while((optIn = getopt(argc, argv, "uhn:l:")) != EOF) {
+        printf("getopt loop running\n");
+        switch(optIn) {
+            case 'u':
+            case 'h':
+                banner(argv[0]);
+                return 0;
+            case 'n':
+                numDevices = atoi(optarg);
+                break;
+            case 'l':
+                numLine = atoi(optarg);
+                break;
+            case '?':
+                if (optopt == 'c') {
+                    std::cerr << "Option -" << optopt << " supplied but number of devices not given" << std::endl;
+                } else if (isprint(optopt)) {
+                    std::cerr << "Unsupported option -"<< optopt << " supplied" << std::endl;
+                } else {
+                    std::cerr << "Unknown option character 0x" << std::hex << optopt << std::endl;
+                    return -1;
+                }
+            default:
+                banner(argv[0]);
+                return -1;
+        }
+    }
+
+    if (numDevices == -1) {
+        std::cout << "Number of controllers not supplied, default value 1 will be used" << std::endl;
+        numDevices = 1;
+    }
+
+    if (numLine == 0) {
+        std::cout << "GPIO Line number not specified, default value zero will be used" << std::endl;
+    }
+    std::cout << std::string(argv[0]) << ": GPIO controllers=" << numDevices <<" GPIO Line=" << numLine << std::endl;
+
+    int chipIndex;
+    struct gpiod_chip *chip;
+    struct gpiod_line *line;
+    std::string gpio_device;
+    bool lineFound = false;
+    for (chipIndex = 0; chipIndex < numDevices; chipIndex++) {
+        chip = gpiod_chip_open_by_number(chipIndex);
+        if (!chip) {
+            std::cerr << "Opening GPIO controller=" << chipIndex << " failed with error=" << errno << std::endl;
+            continue;
+        } else {
+            gpio_device = "/dev/" + std::string(gpiod_chip_name(chip));
+            line = gpiod_chip_get_line(chip, numLine);
+            if (!line) {
+                std::cerr << "GPIO Line=" << numLine << " not found in controller=" << gpio_device << std::endl;
+            } else {
+                std::cout << "GPIO Line=" << numLine << " found within controller=" << gpio_device << std::endl;
+                lineFound = true;
+                gpiod_line_release(line);
+                gpiod_chip_close(chip);
+                break;
+            }
+
+            gpiod_chip_close(chip);
+        }
+    }
+
+    if (lineFound) {
+        if (not gpiod_line_is_free(line)) {
+            std::cerr << "GPIO line with num=" << numLine << " is already under use!" << std::endl;
+            return -1;
+        }
+
+        std::atomic<bool> endFlag {false};
+        std::future<int> monitorF = std::async(std::launch::async, &async_monitor, gpio_device.c_str(), numLine, std::ref(endFlag));
+        if (monitorF.valid()) {
+            auto status = monitorF.wait_for(std::chrono::seconds(PROG_DURATION_IN_SECONDS));
+            if (status == std::future_status::timeout) {
+                std::cout << "Time to end the program successfully!" << std::endl;
+                endFlag = true;
+                return 0;
+            }
+        }
+
+        /* Purposely not retrieving future.get() since the normal case is ending the program after
+         a defined duration */
+
+    } else {
+       std::cerr << "GPIO Line=" << numLine << " not found in any GPIO controller" << std::endl;
+    }
+
+    return -1;
+}

--- a/libgpiod-monitor/main.cpp
+++ b/libgpiod-monitor/main.cpp
@@ -22,7 +22,7 @@ void banner(char *progName)
     std::cout << std::string(progName) << std::endl;
     std::cout << "     -u/h  : Usage message " << std::endl;
     std::cout << "     -n    : Number of GPIO controller to scan, Default range [0,1)" << std::endl;
-    std::cout << "     -l    : Line number to search in GPIO controllersi, Default 0" << std::endl;
+    std::cout << "     -l    : Line number to search in GPIO controllers, Default 0" << std::endl;
 }
 
 /* Asynchronous operator managing callbacks from libgpiod */
@@ -119,7 +119,6 @@ int main(int argc, char **argv)
 
     /* Boilerplate command line arguments processing */
     while((optIn = getopt(argc, argv, "uhn:l:")) != EOF) {
-        printf("getopt loop running\n");
         switch(optIn) {
             case 'u':
             case 'h':

--- a/libgpiod-scan/Makefile
+++ b/libgpiod-scan/Makefile
@@ -1,0 +1,11 @@
+PROJ=libgpiod-scan
+SRC=main.c
+LIBS=-lgpiod
+
+CFLAGS=-Wall -Werror -O2
+CC?=cc
+all:
+	$(CC) $(SRC) $(LIBS) $(CFLAGS) -o $(PROJ)
+
+clean:
+	rm $(PROJ)

--- a/libgpiod-scan/README.md
+++ b/libgpiod-scan/README.md
@@ -1,0 +1,23 @@
+# libgpiod Scan Example
+
+This is a libgpiod client scanning all GPIO controllers for a given GPIO line.
+
+## Build
+```
+make
+```
+
+## Execute
+
+```
+./libgpiod-scan -n 10 -l 44
+```
+
+## Clean
+```
+make clean
+```
+
+## Wiring Example
+
+On a platform with multiple GPIO controllers, informs which one supports the given GPIO line

--- a/libgpiod-scan/main.c
+++ b/libgpiod-scan/main.c
@@ -11,7 +11,7 @@ void banner(char *progName)
     printf("%s: \n", progName);
     printf("     -u/h  : Usage message \n");
     printf("     -n    : Number of GPIO controller to scan, Default range [0,1) \n");
-    printf("     -l    : Line number to search in GPIO controllersi, Default 0 \n");
+    printf("     -l    : Line number to search in GPIO controllers, Default 0 \n");
 }
 /* libgpiod client to scan all possible GPIO controller for a given GPIO Line */
 int main(int argc, char **argv)
@@ -21,9 +21,8 @@ int main(int argc, char **argv)
     int numDevices = -1;
     int numLine = -1;
 
-    // Boilerplate command line arguments processing
+    /* Boilerplate command line arguments processing */
     while((optIn = getopt(argc, argv, "uhn:l:")) != EOF) {
-        printf("getopt loop running\n");
         switch(optIn) {
             case 'u':
             case 'h':

--- a/libgpiod-scan/main.c
+++ b/libgpiod-scan/main.c
@@ -1,0 +1,92 @@
+#include <gpiod.h>
+#include <ctype.h>
+#include <errno.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void banner(char *progName)
+{
+    printf("%s: \n", progName);
+    printf("     -u/h  : Usage message \n");
+    printf("     -n    : Number of GPIO controller to scan, Default range [0,1) \n");
+    printf("     -l    : Line number to search in GPIO controllersi, Default 0 \n");
+}
+/* libgpiod client to scan all possible GPIO controller for a given GPIO Line */
+int main(int argc, char **argv)
+{
+
+    int optIn = 0;
+    int numDevices = -1;
+    int numLine = -1;
+
+    // Boilerplate command line arguments processing
+    while((optIn = getopt(argc, argv, "uhn:l:")) != EOF) {
+        printf("getopt loop running\n");
+        switch(optIn) {
+            case 'u':
+            case 'h':
+                banner(argv[0]);
+                return 0;
+            case 'n':
+                numDevices = atoi(optarg);
+                break;
+            case 'l':
+                numLine = atoi(optarg);
+                break;
+            case '?':
+                if (optopt == 'c') {
+                    fprintf(stderr, "Option -%c supplied but number of devices not given.\n", optopt);
+                } else if (isprint(optopt)) {
+                    fprintf(stderr, "Unsupported option -%c supplied\n", optopt);
+                } else {
+                    fprintf(stderr, "Unknown option character 0x%x\n", optopt);
+                    return -1;
+                }
+            default:
+                banner(argv[0]);
+                return -1;
+        }
+    }
+
+    if (numDevices == -1) {
+        printf("Number of controllers not supplied, default value 1 will be used\n");
+        numDevices = 1;
+    }
+
+    if (numLine == -1) {
+        printf("GPIO Line number not specified, default value zero will be used\n");
+        numLine = 0;
+    }
+    printf("%s: started with GPIO controllers=%d to scan for GPIO Line=%d\n", argv[0], numDevices, numLine);
+
+    int chipIndex;
+    struct gpiod_chip *chip;
+    struct gpiod_line *line;
+    bool lineFound = false;
+    for (chipIndex = 0; chipIndex < numDevices; chipIndex++) {
+        chip = gpiod_chip_open_by_number(chipIndex);
+        if (!chip) {
+            fprintf(stderr, "Opening GPIO controller=%d failed with error=%d\n", chipIndex, errno);
+            continue;
+        } else {
+            line = gpiod_chip_get_line(chip, numLine);
+            if (!line) {
+                fprintf(stderr, "GPIO Line=%d not found in controller=%d\n", numLine, chipIndex);
+            } else {
+                printf("GPIO Line=%d found within controller=%d\n", numLine, chipIndex);
+                /* Break as soon as GPIO line within a controller is found */
+                lineFound = true;
+                gpiod_line_release(line);
+                gpiod_chip_close(chip);
+                break;
+            }
+
+            gpiod_chip_close(chip);
+        }
+    }
+
+    int retVal = lineFound ? 0 : -1;
+    return retVal;
+}


### PR DESCRIPTION
Summary: This patch adds a simple C example to search for a GPIO line
on a Linux platform with multiple GPIO controllers. It also adds another
c++ example using event loop to monitor a GPIO line.